### PR TITLE
Fix incorrectly named var

### DIFF
--- a/server.php
+++ b/server.php
@@ -1177,7 +1177,7 @@
 									"WHERE" => "r.lid = l.id AND l.pid = ?"
 								), $pid);
 
-								while ($row = $result->NextRow())
+								while ($row = $result3->NextRow())
 								{
 									$lids[] = $row->id;
 								}


### PR DESCRIPTION
A incorrectly named var caused the delete product part to crash the server.