### PR TITLE
Update tools.php

### DIFF
--- a/tools.php
+++ b/tools.php
@@ -272,7 +272,7 @@
 			$reason = CLI::GetUserInputWithArgs($args, "reason", "Revoke reason", false, "", $suppressoutput);
 
 			ManageConnection();
-			CLI::DisplayResult($lsrv->RevokeLicense($license["serial_num"], $license["pid"], $license["major_ver"], $license["userinfo"], $reason));
+			CLI::DisplayResult($lsrv->RevokeLicense($license["serial_num"], $license["product_id"], $license["major_ver"], $license["userinfo"], $reason));
 		}
 		else if ($api === "restore")
 		{


### PR DESCRIPTION
Line 275 in Tools.php references "pid", when the proper labeling is "product_id". This was causing the RevokeLicense method to fail when pid's were <> 0.